### PR TITLE
Added variable prefix option in inspector_gadget.gd

### DIFF
--- a/addons/inspector-gadget/src/inspector_gadget.gd
+++ b/addons/inspector-gadget/src/inspector_gadget.gd
@@ -65,13 +65,13 @@ func populate_value(value) -> void:
 			
 			var property_name = property['name']
 			var visual_property_name = property_name
+			# If the variable name starts with the prefix, remove it from the display name,
+			# otherwise dont show the variable.
 			if property_prefix:
 				if property_name.begins_with(property_prefix):
 					visual_property_name = property_name.trim_prefix(property_prefix)
 				else:
 					continue
-			
-			
 			
 			var is_editor_variable = PROPERTY_USAGE_EDITOR & property['usage'] == PROPERTY_USAGE_EDITOR
 

--- a/addons/inspector-gadget/src/inspector_gadget.gd
+++ b/addons/inspector-gadget/src/inspector_gadget.gd
@@ -3,6 +3,7 @@ extends InspectorGadgetBase
 tool
 
 export(Array, String) var property_blacklist := []
+export(String) var property_prefix = ""
 export(Dictionary) var custom_gadget_paths := {}
 export(Dictionary) var custom_gadget_metadata := {}
 export(Dictionary) var container_type_hints := {}
@@ -61,7 +62,17 @@ func populate_value(value) -> void:
 		for property in property_list:
 			if property['name'] in property_blacklist:
 				continue
-
+			
+			var property_name = property['name']
+			var visual_property_name = property_name
+			if property_prefix:
+				if property_name.begins_with(property_prefix):
+					visual_property_name = property_name.trim_prefix(property_prefix)
+				else:
+					continue
+			
+			
+			
 			var is_editor_variable = PROPERTY_USAGE_EDITOR & property['usage'] == PROPERTY_USAGE_EDITOR
 
 			if not is_editor_variable:
@@ -73,10 +84,10 @@ func populate_value(value) -> void:
 				if not is_script_variable:
 					continue
 
-			var property_name = property['name']
+			
 
 			var label = Label.new()
-			label.text = property_name.capitalize()
+			label.text = visual_property_name.capitalize()
 			vbox.add_child(label)
 
 			var gadget: InspectorGadgetBase = get_gadget_for_type(value[property_name], subnames + ":" + property_name, property_name)


### PR DESCRIPTION
This option will only show variables with the specified prefix at the start of the variable name.
For example, say you have a file that looks like this and only want the variables that start with "exposed_" to be seen in the inspector:
```
# Example File
export (Array) exposed_array_var = []
export (Int) exposed_int_var = 5
export (int) var_that_should_not_be_seen = 0
```
Setting the prefix option to `"exposed_"` will make only the exposed variables shown in the inspector, and will remove the prefix from the display name. In the inspector, they will be seen as `Array Var` and `Int Var`.
This is useful for differentiating variables that should be private and variables that should be exposed in code. It's different from using blacklist because it removes the prefix from the display name and is also easier to set up with scripts that have a lot of variables.